### PR TITLE
Adds Even More Fill And Transfer Options

### DIFF
--- a/code/game/objects/items/paint.dm
+++ b/code/game/objects/items/paint.dm
@@ -15,7 +15,7 @@ GLOBAL_LIST_EMPTY(cached_icons)
 	matter = list("metal" = 200)
 	w_class = SIZE_MEDIUM
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(10,20,30,50,70)
+	possible_transfer_amounts = list(5,10,15,20,30,35,40,50,60,70)
 	volume = 70
 	flags_atom = FPRINT|OPENCONTAINER
 	var/paint_type = ""

--- a/code/game/objects/items/reagent_containers/glass.dm
+++ b/code/game/objects/items/reagent_containers/glass.dm
@@ -616,7 +616,7 @@
 	matter = list("metal" = 2000)
 	w_class = SIZE_MEDIUM
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = list(10,20,30,60,120)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,50,60,100,120)
 	volume = 120
 	flags_atom = FPRINT|OPENCONTAINER
 
@@ -685,7 +685,7 @@
 	matter = list("metal" = 4000)
 	w_class = SIZE_LARGE
 	amount_per_transfer_from_this = 20
-	possible_transfer_amounts = list(10,20,30,60,120,240)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,50,60,100,120,150,240)
 	volume = 240
 	flags_atom = FPRINT|OPENCONTAINER
 

--- a/code/game/objects/items/reagent_containers/glass/bottle.dm
+++ b/code/game/objects/items/reagent_containers/glass/bottle.dm
@@ -7,7 +7,7 @@
 	icon_state = "bottle-1"
 	item_state = "bottle-1"
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5, 10, 15, 25, 30, 40, 60)
+	possible_transfer_amounts = list(5, 10, 15, 20, 25, 30, 40, 50, 60)
 	flags_atom = FPRINT|OPENCONTAINER
 	volume = 60
 	attack_speed = 4

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -14,7 +14,7 @@
 	icon_state = "hypo"
 	amount_per_transfer_from_this = 5
 	volume = 30
-	possible_transfer_amounts = list(3, 5, 10, 15, 30)
+	possible_transfer_amounts = list(1,3,5,10,15,20,25,30)
 	flags_atom = FPRINT|OPENCONTAINER
 	flags_equip_slot = SLOT_WAIST
 	flags_item = NOBLUDGEON

--- a/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry_machinery/chem_dispenser.dm
@@ -22,7 +22,7 @@
 	var/accept_beaker_only = TRUE
 	var/obj/item/reagent_container/beaker = null
 	var/ui_check = 0
-	var/static/list/possible_transfer_amounts = list(5,10,20,30,40)
+	var/static/list/possible_transfer_amounts = list(5,10,15,20,30,40,60)
 	/// List of typepaths for reagent containers that a chem dispenser will accept; all containers allowed if empty.
 	var/list/whitelisted_containers = list()
 	var/list/dispensable_reagents = list(

--- a/tgui/packages/tgui/interfaces/ChemMaster.tsx
+++ b/tgui/packages/tgui/interfaces/ChemMaster.tsx
@@ -250,7 +250,7 @@ export const ChemMaster = () => {
   };
 
   return (
-    <Window width={550} height={600}>
+    <Window width={600} height={600}>
       <Window.Content
         className="ChemMaster"
         onClick={() => setDeletingPreset(null)}
@@ -1598,6 +1598,8 @@ const Reagents = (props: {
               <ReagentButton amount={1} reagent={reagent} type={type} />
               <ReagentButton amount={5} reagent={reagent} type={type} />
               <ReagentButton amount={10} reagent={reagent} type={type} />
+              <ReagentButton amount={15} reagent={reagent} type={type} />
+              <ReagentButton amount={20} reagent={reagent} type={type} />
               <ReagentButton amount={30} reagent={reagent} type={type} />
               <ReagentButton amount={60} reagent={reagent} type={type} />
               <ReagentButton amount={'All'} reagent={reagent} type={type} />


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->

# About the pull request

Adds more transfer options to reagent containers of all types
2. Adds more unit transfer options to the Chemmaster and Chemical Dispenser.

Changes have been tested.

# Explain why it's good for the game

1. More options is gud!
2. There was enough space in the Chem Dispenser UI for more slots. Also, I only needed to resize the width of the Chem Master window 50 pixels more horizontally.

# Testing Photographs and Procedure

<details>
<summary>Screenshots & Videos</summary>

New Chemical Dispenser buttons
<img width="435" height="620" alt="image" src="https://github.com/user-attachments/assets/fe163a4f-eee4-4767-ba7d-745afb6cffb7" />

New ChemMaster 3000 buttons
<img width="600" height="600" alt="image" src="https://github.com/user-attachments/assets/77379b67-8d58-4079-ab2c-5632a0d89d5b" />

</details>


# Changelog

:cl: Puckaboo2
add: Adds more Set Transfer Amount unit options to most reagent containers.
ui: Adds 15 and 60 unit Dispense and Beaker options for the Chemical Dispenser and its derivatives. 
ui: Adds 15 and 20 unit options for the ChemMaster 3000 and its derivatives.
ui: Increased the size of the Chemmaster 3000 window to 600 from 550 to fit the new buttons without distorting text too much.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! -->
